### PR TITLE
Modify API reference class template to only display sections with members

### DIFF
--- a/docs/source/_templates/api_reference_class_template.rst
+++ b/docs/source/_templates/api_reference_class_template.rst
@@ -13,48 +13,67 @@
    {% block methods %}
    .. automethod:: __init__
 
-   {% if methods %}
+   {%- set methods_non_inherited = [] %}
+   {%- set methods_inherited = [] %}
+
+   {%- for item in methods %}
+      {%- if item not in inherited_members %}
+         {{- methods_non_inherited.append(item) or '' }}
+      {%- else %}
+         {{- methods_inherited.append(item) or '' }}
+      {%- endif %}
+   {%- endfor %}
+
+   {% if methods_non_inherited %}
    .. rubric:: {{ _('Methods') }}
 
    .. autosummary::
-   {% for item in methods %}
-      {%- if item not in inherited_members %}
+   {% for item in methods_non_inherited %}
       ~{{ name }}.{{ item }}
-      {%- endif %}
    {%- endfor %}
+   {% endif %}
 
+   {% if methods_inherited %}
    .. rubric:: {{ _('Inherited Methods') }}
 
    .. autosummary::
-   {% for item in methods %}
-      {%- if item in inherited_members %}
+   {% for item in methods_inherited %}
       ~{{ name }}.{{ item }}
-      {%- endif %}
    {%- endfor %}
-
    {% endif %}
+
    {% endblock %}
 
 
    {% block attributes %}
-   {% if attributes %}
+
+   {%- set attributes_non_inherited = [] %}
+   {%- set attributes_inherited = [] %}
+
+   {%- for item in attributes %}
+      {%- if item not in inherited_members %}
+         {{- attributes_non_inherited.append(item) or '' }}
+      {%- else %}
+         {{- attributes_inherited.append(item) or '' }}
+      {%- endif %}
+   {%- endfor %}
+
+   {% if attributes_non_inherited %}
    .. rubric:: {{ _('Attributes') }}
 
    .. autosummary::
-   {% for item in attributes %}
-      {%- if item not in inherited_members %}
+   {% for item in attributes_non_inherited %}
       ~{{ name }}.{{ item }}
-      {%- endif %}
    {%- endfor %}
+   {% endif %}
 
+   {% if attributes_inherited %}
    .. rubric:: {{ _('Inherited Attributes') }}
 
    .. autosummary::
-   {% for item in attributes %}
-      {%- if item in inherited_members %}
+   {% for item in attributes_inherited %}
       ~{{ name }}.{{ item }}
-      {%- endif %}
    {%- endfor %}
-
    {% endif %}
+
    {% endblock %}


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Major Changes and Improvements
- Modified API reference class template such that the "Methods," "Inherited Methods," "Attributes," and "Inherited Attributes" sections are only displayed if there are members in the section

## Notes and References
- [Jinja Template Designer Documentation](https://jinja.palletsprojects.com/en/3.1.x/templates/)
- [Sphinx Templating](https://www.sphinx-doc.org/en/master/templating.html)
- Useful StackOverflow posts
  - https://stackoverflow.com/questions/49619445/how-to-append-to-a-list-in-jinja2-for-ansible
  - https://stackoverflow.com/questions/23129195/if-statement-on-for-statement-in-jinja2
  - https://stackoverflow.com/questions/11146619/suppress-none-output-as-string-in-jinja2