### PR TITLE
Improve `pyxx.files.TextFile.read()` error message if file does not exist

### DIFF
--- a/pyxx/files/classes/textfile.py
+++ b/pyxx/files/classes/textfile.py
@@ -309,6 +309,10 @@ class TextFile(File):
                     '"path" attribute defined.  At least one of these must '
                     'be provided to read the file')
 
+        # Check that file exists
+        if not self.path.is_file():
+            raise FileNotFoundError(f'Cannot find file "{self.path}"')
+
         # Compute and store file hashes
         self.store_file_hashes()
 

--- a/tests/files/classes/test_textfile.py
+++ b/tests/files/classes/test_textfile.py
@@ -557,6 +557,12 @@ class Test_TextFile_Read(unittest.TestCase):
         with self.assertRaises(AttributeError):
             file.read()
 
+    def test_missing_file(self):
+        # Verifies that an error is thrown if file does not exist
+        file = TextFile(path = SAMPLE_FILES_DIR / 'non_existent_file.docx')
+        with self.assertRaises(FileNotFoundError):
+            file.read()
+
     def test_set_path(self):
         # Verifies that logic to set path matches expectations
         with self.subTest(path='argument_only'):


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Minor Updates
- Previously, if attempting to read a file with `pyxx.files.TextFile.read()` and the file did not exist, a somewhat confusing message about not being able to compute hashes was produced.  This message was improved to make it more specific to the root cause of the error