### PR TITLE
Add note to installation instructions about command-line utility availability

### DIFF
--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -35,7 +35,10 @@ Source Code
 -----------
 
 Alternatively, if you prefer to download the source code directly, you can do
-so using Git.  First, clone the source repository to a location of your choice:
+so using Git.  Note that some functionality, such as command-line utilities,
+will not be available if setting up |PackageNameStylized| using this method.
+
+First, clone the source repository to a location of your choice:
 
 .. code-block:: shell
 


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Minor Updates
- Added a note to the "installation" page in the documentation that functionality such as command-line utilities isn't available if running package directly from cloned source files