### PR TITLE
Remove deprecated GitHub Actions output commands

### DIFF
--- a/.github/workflows/_get_matrix_config.yml
+++ b/.github/workflows/_get_matrix_config.yml
@@ -29,4 +29,4 @@ jobs:
 
       - name: Set up Workflow Matrix
         id: set-matrix
-        run: echo "::set-output name=matrix::${{ env.WORKFLOW_MATRIX_CONFIG }}"
+        run: echo "matrix=${{ env.WORKFLOW_MATRIX_CONFIG }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/_matrix_output_success.yml
+++ b/.github/workflows/_matrix_output_success.yml
@@ -29,4 +29,4 @@ jobs:
     steps:
       - name: Output Workflow Success
         id: set-output
-        run: echo "::set-output name=success::true"
+        run: echo "success=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Minor Updates
- The previous method for setting GitHub Actions outputs is deprecated and has been replaced by writing content to the `GITHUB_OUTPUT` file.  This change removes the deprecated commands and replaces them with GitHub's recommended fix.

## Notes and References
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/