### PR TITLE
Fix comment in installation instructions in wrong location

### DIFF
--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -90,6 +90,9 @@ First, clone the source repository to a location of your choice:
 
             C:\>git clone https://github.com/nathan-hess/python-utilities.git
 
+        Note that it is not recommended that you download the source code to
+        your ``C:\`` directory; this is merely shown as a general example.
+
 Then, add the root directory of the repository to your ``PYTHONPATH`` environment
 variable:
 
@@ -108,9 +111,6 @@ variable:
         .. code-block:: powershell
 
             C:\>set PYTHONPATH=%PYTHONPATH%;%CD%\python-utilities
-
-        Note that it is not recommended that you download the source code to
-        your ``C:\`` directory; this is merely shown as a general example.
 
 Finally, make sure to install required dependencies through pip:
 


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Bug Fixes
- A comment about installation directory was located next to the wrong command in the installation instructions in the documentation.  This moves the content to the intended location