### PR TITLE
Remove link to unit examples in `pyxx.units.Unit.convert()`

### DIFF
--- a/pyxx/units/classes/unit.py
+++ b/pyxx/units/classes/unit.py
@@ -433,10 +433,6 @@ class Unit:
         np.ndarray
             NumPy array of the same shape as ``value`` containing the
             quantities after performing the specified unit conversion
-
-        Examples
-        --------
-        For examples, refer to the :ref:`section-examples_units` page.
         """
         # Validate input argument types
         if not isinstance(convert_type, str):


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Minor Updates
- Removed link to unit examples page in `pyxx.units.Unit.convert()` method docstring. This link is redundant since the same link is already provided in the class description, and this can cause problems for other packages that inherit the `pyxx.units.Unit` class, since their documentation may inherit this docstring and if so, this link will likely be broken in their documentation