### PR TITLE
Fix bug preventing copying data files when installing package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ project_urls =
 
 [options]
 python_requires = >=3.8
+include_package_data = True
 install_requires = file: requirements.txt
 packages = find:
 


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Bug Fixes
- This change specifies `include_package_data = True` in `setup.cfg`
  - Previously, this option was not specified, and as a result, the `py.typed` file was not installed.  This led to Mypy errors in packages for which PyXX is a dependency

## Tests and Validation
- Verified that when installing the updated package from Test PyPI, the `py.typed` file was copied into the installation directory

## Notes and References
- https://setuptools.pypa.io/en/latest/userguide/datafiles.html
- https://stackoverflow.com/questions/70921421/my-python-multi-module-package-wont-distribute-with-a-py-typed-file