### PR TITLE
Make `pyxx.arrays.max_list_item_len()` type hint more general

### DIFF
--- a/pyxx/arrays/functions/size.py
+++ b/pyxx/arrays/functions/size.py
@@ -1,7 +1,7 @@
 """Functions for evaluating or comparing sizes of array-like objects
 """
 
-from typing import Any, Union
+from typing import Any, Iterable
 
 
 def check_len_equal(item1: Any, item2: Any, *args: Any):
@@ -85,7 +85,7 @@ def is_len_equal(item1: Any, item2: Any, *args: Any) -> bool:
     return True
 
 
-def max_list_item_len(input_list: Union[list, tuple]) -> int:
+def max_list_item_len(input_list: Iterable) -> int:
     """Finds the maximum length of any item in a list or tuple
 
     Parameters


### PR DESCRIPTION
Fixed type hint so that the `max_list_item_len()` function can be used with `dict` keys

<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Minor Updates
- The `pyxx.arrays.max_list_item_len()` function can iterate over any iterable; however, previously the type hints specified only lists and tuples.  This change uses the more general `Iterable` class for the type hint to avoid Mypy errors
  - Example case: if using this function to iterate over `dict` keys, this previously generated a Mypy error