### PR TITLE
Fix typo in docstring

### DIFF
--- a/pyxx/arrays/classes/typedlist.py
+++ b/pyxx/arrays/classes/typedlist.py
@@ -73,7 +73,7 @@ class TypedList(MutableSequence[T]):
             The required type of all items in the list
         print_multiline : bool, optional
             Whether to return a printable string representation of the list in
-            multiline format (default is ``True``).  Multiline format places
+            multiline format (default is ``False``).  Multiline format places
             each item in the list on its own line
         multiline_padding : int, optional
             The amount of horizontal padding to place between brackets and


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Bug Fixes
- Fixed incorrect default value for parameter in `pyxx.arrays.TypedList` docstring