### PR TITLE
Fix bug in which unit converter considered blank units to be defined

### DIFF
--- a/pyxx/units/classes/unitconverter.py
+++ b/pyxx/units/classes/unitconverter.py
@@ -540,6 +540,9 @@ class UnitConverter(Dict[str, UnitConverterEntry]):
         """
         component_units = parse_unit(str(unit)).keys()
 
+        if len(component_units) == 0:
+            return False
+
         for component in component_units:
             if component not in self:
                 return False

--- a/tests/units/classes/test_unitconverter.py
+++ b/tests/units/classes/test_unitconverter.py
@@ -714,6 +714,9 @@ class Test_UnitConverter(unittest.TestCase):
             for unit in ('kg*in/s^2', 'in/s', 'in/hr'):
                 self.assertFalse(self.unit_converter.is_defined_unit(unit))
 
+        with self.subTest(unit_type='blank', defined=False):
+            self.assertFalse(self.unit_converter.is_defined_unit(''))
+
     def test_is_simplified(self):
         # Verifies that simple vs. compound units are distinguished correctly
         test_cases = (


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Bug Fixes
- Fixed bug in which the `pyxx.units.UnitConverter.is_defined_unit()` method would previously (and incorrectly) return `True` for empty strings