### PR TITLE
Fix blank unit conventions

### DIFF
--- a/pyxx/units/classes/unitconverter.py
+++ b/pyxx/units/classes/unitconverter.py
@@ -741,6 +741,10 @@ class UnitConverter(Dict[str, UnitConverterEntry]):
             A :py:class:`Unit` object representation of the unit specified
             by ``unit``
         """
+        if unit.strip() == '':
+            raise UnitNotFoundError(
+                f'Unit "{unit}" consists only of whitespace and is not valid')
+
         parsed_unit = parse_unit(unit)
 
         # For special case of dimensionless units, output a constant unit

--- a/tests/units/classes/test_unitconverter.py
+++ b/tests/units/classes/test_unitconverter.py
@@ -674,6 +674,17 @@ class Test_UnitConverter(unittest.TestCase):
             with self.assertRaises(IncompatibleUnitsError):
                 self.unit_converter.convert(quantity=100, from_unit='kg', to_unit='mm')
 
+    def test_convert_dimensionless(self):
+        # Verifies that for an edge case of converting between a blank unit ""
+        # and a dimensionless unit, an exception is thrown
+        self.unit_converter_empty['dimensionless'] = self.entry_dimensionless
+
+        with self.assertRaises(UnitNotFoundError):
+            self.unit_converter_empty.convert(10, from_unit='dimensionless', to_unit='')
+
+        with self.assertRaises(UnitNotFoundError):
+            self.unit_converter_empty.convert(10, from_unit='', to_unit='dimensionless')
+
     def test_is_convertible(self):
         # Verifies that incompatible units are recognized
         test_cases = (
@@ -964,12 +975,3 @@ class Test_UnitConverter(unittest.TestCase):
             inputs = 100 * np.random.randn(100)
             self.assertTrue(np.allclose(unit.to_base(inputs), inputs / 1000))
             self.assertTrue(np.allclose(unit.from_base(inputs), inputs * 1000))
-
-        with self.subTest(unit='[empty]'):
-            unit = self.unit_converter.str_to_unit('')
-
-            self.assertListEqual(list(unit.base_unit_exps), [0, 0, 0, 0, 0, 0, 0])
-
-            inputs = 100 * np.random.randn(100)
-            self.assertTrue(np.allclose(unit.to_base(inputs), inputs))
-            self.assertTrue(np.allclose(unit.from_base(inputs), inputs))


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Bug Fixes
- Fixed inconsistent and potentially confusing behavior around "empty" or "blank" units (example: `''`)
  - Fixed implementation of `UnitConverter.is_defined_unit()` so that it returns `False` for "empty" units but not for dimensionless units such as `m/m`
  - Added exception if attempting to convert units with an "empty" unit. Unit conversions with such units are not intuitive, so preventing them entirely avoids potential confusion