### PR TITLE
Prevent duplicate workflow run on releases

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags-ignore:
+      - '**'
   pull_request:
     types: [opened, reopened, synchronize]
   release:


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Bug Fixes
- Added exclusion for CI/CD workflow tag trigger to prevent the workflow from running twice when GitHub releases are published (once triggered by the release and once triggered by the tag)