### PR TITLE
Update GitHub Actions dependency versions

### DIFF
--- a/.github/workflows/_get_matrix_config.yml
+++ b/.github/workflows/_get_matrix_config.yml
@@ -22,7 +22,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Check Out Repository Files
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Setup Action
         uses: ./.github/workflows/composite-actions/load-workflow-config

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -34,7 +34,7 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     steps:
       - name: Check Out Repository Files
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Setup Action
         uses: ./.github/workflows/composite-actions/setup
@@ -72,7 +72,7 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     steps:
       - name: Check Out Repository Files
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Setup Action
         uses: ./.github/workflows/composite-actions/setup
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Repository Files
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Setup Action
         uses: ./.github/workflows/composite-actions/setup
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Repository Files
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Setup Action
         uses: ./.github/workflows/composite-actions/setup
@@ -171,7 +171,7 @@ jobs:
         run: twine check --strict dist/*
 
       - name: Upload Package as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist-upload
           path: dist/

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Repository Files
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Setup Action
         uses: ./.github/workflows/composite-actions/setup

--- a/.github/workflows/composite-actions/setup/action.yml
+++ b/.github/workflows/composite-actions/setup/action.yml
@@ -26,13 +26,13 @@ runs:
       uses: ./.github/workflows/composite-actions/load-workflow-config
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       if: ${{ inputs.python-version != 'release' }}
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Set up Python (Version Used for Packaging Releases)
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       if: ${{ inputs.python-version == 'release' }}
       with:
         python-version: ${{ env.PYTHON_RELEASE_VERSION }}


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Minor Updates
- Updated GitHub Actions dependencies to latest versions due to old versions becoming deprecated (switching from Node.js 16 to 20)

## Notes and References
- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/